### PR TITLE
Changed where the SPI is initialized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/include/PrometheusTeleoperation-MotorsSetup.h
+++ b/include/PrometheusTeleoperation-MotorsSetup.h
@@ -7,9 +7,9 @@
 /* Motors declaration*/
 // * Motors declaration
 CanMotor *motors[] = {
-    new MitMotor(MitMotor::AK_10, CS_0, INT_0, "AK_10_1"),
-    new MitMotor(MitMotor::AK_10, CS_1, INT_1, "AK_10_2"),
-    new MitMotor(MitMotor::AK_10, CS_2, INT_2, "AK_10_3")};
+    new MitMotor(MitMotor::AK_10, CS_0, INT_0, "AK_10_1", SPI, false),
+    new MitMotor(MitMotor::AK_10, CS_1, INT_1, "AK_10_2", SPI, false),
+    new MitMotor(MitMotor::AK_10, CS_2, INT_2, "AK_10_3", SPI, false)};
 
 constexpr size_t NUM_MOTORS = sizeof(motors) / sizeof(motors[0]);
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,6 +19,7 @@ lib_deps =
 platform = teensy
 board = teensy41
 framework = arduino
+monitor_speed = 115200
 build_flags =
     ; ---- ---- ---- ---- ---- // you may remove logs made with the macros in IpScheme.h
     -D DEBUG_LOG

--- a/src/StateMachine.cpp
+++ b/src/StateMachine.cpp
@@ -12,6 +12,7 @@
 
 #include <tuple>
 #include "StateMachine.h"
+#include "SPI.h"
 
 #define A_THOUSAND 1000
 
@@ -38,6 +39,7 @@ void setup()
     //   ; // wait for serial port to connect. Needed for native USB port only.
     // }
   #endif
+  SPI.begin();
   p2pComm.begin(); // Ethernet start; the cofiguration come from the McuConfig object.
 }
 

--- a/src/mecanum_4wd.cpp
+++ b/src/mecanum_4wd.cpp
@@ -28,10 +28,10 @@ SimpleCmdVel mecanum4WD_velocity_read{0.0, 0.0, 0.0};
 //Motor pins
 const MitMotor::MotorType AK_10_REVERSED{-18.0f, 18.0f, 1.0f, -1.0f};
 CanMotor * wheel_motors[] = {
-    new MitMotor(MitMotor::AK_10, CS_3, INT_3, "Wheel 0"),
-    new MitMotor(AK_10_REVERSED, CS_4, INT_4, "Wheel 1"),
-    new MitMotor(AK_10_REVERSED, CS_5, INT_5, "Wheel 2"),
-    new MitMotor(AK_10_REVERSED, CS_6, INT_6, "Wheel 3")
+    new MitMotor(MitMotor::AK_10, CS_3, INT_3, "Wheel 0", SPI, false),
+    new MitMotor(AK_10_REVERSED, CS_4, INT_4, "Wheel 1", SPI, false),
+    new MitMotor(AK_10_REVERSED, CS_5, INT_5, "Wheel 2", SPI, false),
+    new MitMotor(AK_10_REVERSED, CS_6, INT_6, "Wheel 3", SPI, false)
 };
 
 //Interruptioin pins


### PR DESCRIPTION
Changed the location where the SPI is initialized because it caused problems with Teensy 4.1 causing reboots.